### PR TITLE
[fix] Fix the bug that "hideTitleBar" doesn't work

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ function WebUI (context, htmlName, options) {
   panel.setTitle(options.title || context.plugin.name())
   if (options.hideTitleBar) {
     panel.setTitlebarAppearsTransparent(true)
+    panel.setTitleVisibility(NSWindowTitleHidden)
   }
 
   panel.becomeKeyWindow()


### PR DESCRIPTION
"panel.setTitlebarAppearsTransparent(true)" only make titlebar transparent, but won't hide it.